### PR TITLE
Add logic to detect incorrect calls to `ErReturnToSender()`

### DIFF
--- a/eventrouter.h
+++ b/eventrouter.h
@@ -37,7 +37,7 @@ extern "C"
     {
         /// These fields list all tasks that can participate in event routing.
         /// The tasks should be listed from highest priority to lowest.
-        const ErTask_t *m_tasks;
+        ErTask_t *m_tasks;
         size_t m_num_tasks;
 
         /// Returns true if the current execution context is an interrupt
@@ -102,11 +102,19 @@ extern "C"
     /// error.
     void ErCallHandlers(ErEvent_t *a_event);
 
-    /// If an event handler "keeps" and event, indicated by returning
-    /// `ER_EVENT_HANDLER_RET__KEPT`, they are responsible for calling this
-    /// function on the event when they are done with it. Said differently, the
-    /// event handler must call this function once if and only if it returns
-    /// `ER_EVENT_HANDLER_RET__KEPT`.
+    /// Returns an event which a module previously KEPT.
+    ///
+    /// Modules KEEP events by returning `ER_EVENT_HANDLER_RET__KEPT` from their
+    /// event handler. Keeping an event lets a module inspect the contents of
+    /// that event across multiple calls to their event handler. Normally,
+    /// modules lose access to an event after their event handler returns.
+    ///
+    /// When modules are done with an event they have previously KEPT, they must
+    /// call `ErReturnToSender()` on that event. This lets the sender reclaim
+    /// the resources for that event and reuse it. Modules MUST NOT call
+    /// `ErReturnToSender()` in the same handler call that they return
+    /// `ER_EVENT_HANDLER_RET__KEPT`; it corrupts the reference count achieves
+    /// the same thing as returning `ER_EVENT_HANDLER_RET__HANDLED` instead.
     void ErReturnToSender(ErEvent_t *a_event);
 
     /// Causes the event router to deliver all events of `a_event_type` to this

--- a/eventrouter/internal/eventrouter_freertos.c
+++ b/eventrouter/internal/eventrouter_freertos.c
@@ -407,7 +407,7 @@ void ErCallHandlers(ErEvent_t *a_event)
     }
 
     const size_t task_idx = GetIndexOfCurrentTask();
-    const ErTask_t *task  = &s_context.m_options->m_tasks[task_idx];
+    ErTask_t *task        = &s_context.m_options->m_tasks[task_idx];
 
     for (size_t module_idx = 0; module_idx < task->m_num_modules; ++module_idx)
     {
@@ -426,8 +426,11 @@ void ErCallHandlers(ErEvent_t *a_event)
 
         if (module_is_subscribed)
         {
-            // Deliver the event to the subscribed module.
+            // Deliver the event to the subscribed module and setup state to
+            // detect incorrect calls to `ErReturnToSender()` in the handler.
+            task->m_current_event         = a_event;
             const ErEventHandlerRet_t ret = module->m_handler(a_event);
+            task->m_current_event         = NULL;
 
             if (ret == ER_EVENT_HANDLER_RET__KEPT)
             {
@@ -454,7 +457,22 @@ void ErReturnToSender(ErEvent_t *a_event)
 
     const int previous_reference_count =
         atomic_fetch_sub(&a_event->m_reference_count, 1);
-    const int reference_count = previous_reference_count - 1;
+    const int reference_count     = previous_reference_count - 1;
+    const size_t sending_task_idx = a_event->m_sending_module->m_task_idx;
+    const ErTask_t *sending_task =
+        &s_context.m_options->m_tasks[sending_task_idx];
+
+    // Clients should not call `ErReturnToSender()` on an event in the same
+    // handler call that they receive it; it messes up the reference count and
+    // they can do the same thing by returning `ER_EVENT_HANDLER_RET__HANDLED`.
+    //
+    // This constraint prevents subscribers from KEEPing events which are sent
+    // multiple times using `ErSendEx()`. Without this check a subscriber could
+    // receive an event which it had previously KEPT, return the previously KEPT
+    // copy, and then KEEP the new copy. I can't see how this flow could be
+    // useful and think that preventing incorrect calls to `ErReturnToSender()`
+    // is more useful.
+    ER_ASSERT(sending_task->m_current_event != a_event);
 
     if (reference_count > 1)
     {
@@ -468,15 +486,12 @@ void ErReturnToSender(ErEvent_t *a_event)
         // All the recipient tasks are done with the event. We must return the
         // event to its sender.
 
-        const size_t sending_task_idx = a_event->m_sending_module->m_task_idx;
-
         // The sending task is different from the current task, so we need to
         // send it to that task's queue.
         if (sending_task_idx != GetIndexOfCurrentTask())
         {
-            s_context.m_rtos_functions.SendEvent(
-                s_context.m_options->m_tasks[sending_task_idx].m_event_queue,
-                a_event);
+            s_context.m_rtos_functions.SendEvent(sending_task->m_event_queue,
+                                                 a_event);
 
             // The `return` below is necessary to prevent double-delivery of
             // events to the sending module. The problematic case, without this

--- a/eventrouter/internal/task_.h
+++ b/eventrouter/internal/task_.h
@@ -13,7 +13,7 @@
 #include "task.h"
 #endif  // ER_FREERTOS
 
-#include "event_type.h"
+#include "event.h"
 #include "module.h"
 
 #ifdef __cplusplus
@@ -31,6 +31,9 @@ extern "C"
         /// A superset of all module subscriptions within the task.
         uint8_t
             m_subscriptions[(ER_EVENT_TYPE__COUNT + (CHAR_BIT - 1)) / CHAR_BIT];
+        /// The event that this task is currently handling. This is used to
+        /// detect incorrect uses of `ErReturnToSender()`.
+        ErEvent_t *m_current_event;
 #endif  // ER_FREERTOS
 
         /// The list of modules this task contains; multiple tasks MUST NOT


### PR DESCRIPTION
I have seen a recurring mistake where modules attempt to call `ErReturnToSender()` in the same handler-call that they eventually return `ER_EVENT_HANDLER_RET__KEPT`. This PR adds logic to detect that defect and abort and updates the documentation to (hopefully) make things clearer.