### PR TITLE
Revert "Add logic to detect incorrect calls to `ErReturnToSender()`"

### DIFF
--- a/eventrouter.h
+++ b/eventrouter.h
@@ -37,7 +37,7 @@ extern "C"
     {
         /// These fields list all tasks that can participate in event routing.
         /// The tasks should be listed from highest priority to lowest.
-        ErTask_t *m_tasks;
+        const ErTask_t *m_tasks;
         size_t m_num_tasks;
 
         /// Returns true if the current execution context is an interrupt
@@ -102,19 +102,11 @@ extern "C"
     /// error.
     void ErCallHandlers(ErEvent_t *a_event);
 
-    /// Returns an event which a module previously KEPT.
-    ///
-    /// Modules KEEP events by returning `ER_EVENT_HANDLER_RET__KEPT` from their
-    /// event handler. Keeping an event lets a module inspect the contents of
-    /// that event across multiple calls to their event handler. Normally,
-    /// modules lose access to an event after their event handler returns.
-    ///
-    /// When modules are done with an event they have previously KEPT, they must
-    /// call `ErReturnToSender()` on that event. This lets the sender reclaim
-    /// the resources for that event and reuse it. Modules MUST NOT call
-    /// `ErReturnToSender()` in the same handler call that they return
-    /// `ER_EVENT_HANDLER_RET__KEPT`; it corrupts the reference count achieves
-    /// the same thing as returning `ER_EVENT_HANDLER_RET__HANDLED` instead.
+    /// If an event handler "keeps" and event, indicated by returning
+    /// `ER_EVENT_HANDLER_RET__KEPT`, they are responsible for calling this
+    /// function on the event when they are done with it. Said differently, the
+    /// event handler must call this function once if and only if it returns
+    /// `ER_EVENT_HANDLER_RET__KEPT`.
     void ErReturnToSender(ErEvent_t *a_event);
 
     /// Causes the event router to deliver all events of `a_event_type` to this

--- a/eventrouter/internal/task_.h
+++ b/eventrouter/internal/task_.h
@@ -13,7 +13,7 @@
 #include "task.h"
 #endif  // ER_FREERTOS
 
-#include "event.h"
+#include "event_type.h"
 #include "module.h"
 
 #ifdef __cplusplus
@@ -31,9 +31,6 @@ extern "C"
         /// A superset of all module subscriptions within the task.
         uint8_t
             m_subscriptions[(ER_EVENT_TYPE__COUNT + (CHAR_BIT - 1)) / CHAR_BIT];
-        /// The event that this task is currently handling. This is used to
-        /// detect incorrect uses of `ErReturnToSender()`.
-        ErEvent_t *m_current_event;
 #endif  // ER_FREERTOS
 
         /// The list of modules this task contains; multiple tasks MUST NOT


### PR DESCRIPTION
This reverts commit b0f7f7d6340b5781e3a5efe573b8e68b3126abe9.

The use case where we return KEPT copies of resendable events  ends up being valuable.