### PR TITLE
Initialize m_reference_count in INIT_ER_EVENT()

### DIFF
--- a/eventrouter/internal/event.h
+++ b/eventrouter/internal/event.h
@@ -82,8 +82,13 @@ extern "C"
     /// Initialize the event fields of a struct which mixes-in `ErEvent_t`
     /// behavior. This differs from `ErEventInit_t` in that it can be used in
     /// static definitions using designated initializers.
+#ifdef __cplusplus
 #define INIT_ER_EVENT(a_type, a_module) \
-    .ER_EVENT_MEMBER = {.m_type = a_type, .m_sending_module = a_module}
+    .ER_EVENT_MEMBER = {.m_type = a_type, .m_reference_count = {0}, .m_sending_module = a_module}
+#else
+#define INIT_ER_EVENT(a_type, a_module) \
+    .ER_EVENT_MEMBER = {.m_type = a_type, .m_reference_count = 0, .m_sending_module = a_module}
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I add initialization of `m_reference_count` in `INIT_ER_EVENT()`

A missing initializer on old gcc/c++ induces
"sorry, unimplemented: non-trivial designated initializers not supported". 
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55606