### PR TITLE
initialize m_next field in ErEventInit() in case ER_BAREMETAL

### DIFF
--- a/eventrouter/internal/event.h
+++ b/eventrouter/internal/event.h
@@ -44,6 +44,9 @@ extern "C"
         a_event->m_type            = a_type;
         a_event->m_reference_count = 0;
         a_event->m_sending_module  = a_module;
+#ifdef ER_BAREMETAL
+        a_event->m_next.m_next = NULL;
+#endif
     }
 
     /// Add this to the top-level of a struct definition to make values of that


### PR DESCRIPTION
Sometimes I get the below assert when using eventrouter with ER_BAREMETAL.
In this pr, initialize the `m_next` field of `ErEvent_t` structure with `NULL` when `ErEventInit()` is executed.

```
kaden0: /home/kagaya/LFTC/device-app/yohana/thirdparty/eventrouter/repo/eventrouter/internal/eventrouter_baremetal.c:100: ErSendEx: Assertion `a_event->m_next.m_next == ((void *)0)' failed.
```
