### PR TITLE
Small 3.0.0 fixes

### DIFF
--- a/eventrouter/internal/queue_.h
+++ b/eventrouter/internal/queue_.h
@@ -6,26 +6,37 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-/// An opaque queue type for ErEvent_t* elements.
-typedef void* ErQueue_t;
-typedef ErQueue_t ErQueueHandle_t;
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
-/// Allocates a new `ErQueue_t` which can hold at most `a_capacity` elements.
-ErQueue_t ErQueueNew(size_t a_capacity);
+    /// An opaque queue type for ErEvent_t* elements.
+    typedef void* ErQueue_t;
+    typedef ErQueue_t ErQueueHandle_t;
 
-/// Frees a `ErQueue_t` previously allocated with `ErQueueNew()`.
-void ErQueueFree(ErQueue_t a_queue);
+    /// Allocates a new `ErQueue_t` that can hold at most `a_capacity` elements.
+    ErQueue_t ErQueueNew(size_t a_capacity);
 
-/// Blocks until there is a value to read from `a_queue`, then returns it.
-ErEvent_t* ErQueuePopFront(ErQueue_t a_queue);
+    /// Frees a `ErQueue_t` previously allocated with `ErQueueNew()`.
+    void ErQueueFree(ErQueue_t a_queue);
 
-/// Blocks until there is space to write `a_event` to the queue, then returns.
-void ErQueuePushBack(ErQueue_t a_queue, ErEvent_t* a_event);
+    /// Blocks until there is a value to read from `a_queue`, then returns it.
+    ErEvent_t* ErQueuePopFront(ErQueue_t a_queue);
 
-/// Returns true if `a_event` was read from `a_queue` within `a_ms`.
-bool ErQueueTimedPopFront(ErQueue_t a_queue, ErEvent_t** a_event, int64_t a_ms);
+    /// Blocks until there is space to write to the queue, then returns.
+    void ErQueuePushBack(ErQueue_t a_queue, ErEvent_t* a_event);
 
-/// Returns true if `a_event` was written to `a_queue` within `a_ms`.
-bool ErQueueTimedPushBack(ErQueue_t a_queue, ErEvent_t* a_event, int64_t a_ms);
+    /// Returns true if `a_event` was read from `a_queue` within `a_ms`.
+    bool ErQueueTimedPopFront(ErQueue_t a_queue, ErEvent_t** a_event,
+                              int64_t a_ms);
+
+    /// Returns true if `a_event` was written to `a_queue` within `a_ms`.
+    bool ErQueueTimedPushBack(ErQueue_t a_queue, ErEvent_t* a_event,
+                              int64_t a_ms);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* EVENTROUTER_QUEUE_H */

--- a/extra/test/mock_os.h
+++ b/extra/test/mock_os.h
@@ -69,6 +69,8 @@ struct MockOs
 
     static bool IsInIsr(void) { return false; }
 
+    static int64_t GetTimeMs(void) { return m_now_ms; }
+
     static ErOptions_t m_event_router_options;
     static ErTaskHandle_t m_running_task;
     static std::unordered_map<ErQueueHandle_t, std::queue<ErEvent_t *>>


### PR DESCRIPTION
This PR adds:
- A missing method to `mock_os.h`; and
- `extern "C` guards to `queue_.h`.

I recommend checking the box that says "hide whitespace" when viewing the diff.