### PR TITLE
IOTA-688 Add `ErTryClaim()`

### DIFF
--- a/eventrouter.h
+++ b/eventrouter.h
@@ -130,6 +130,13 @@ extern "C"
     //============================================================================
 
 #ifdef ER_CONFIG_OS
+    /// Returns true if the caller successfully claimed the event and false
+    /// otherwise. Callers in non-owning tasks must claim events before sending
+    /// them with `ErSend()` or `ErSendEx()`; the implementation checks this and
+    /// asserts if violated. For more information see "Claiming Events" section
+    /// at the top of this file.
+    bool ErTryClaim(ErEvent_t *a_event);
+
     /// Blocks until the next event sent to the current task is received, and
     /// returns it; asserts if called from an interrupt.
     ErEvent_t *ErReceive(void);

--- a/eventrouter/internal/atom_lock.h
+++ b/eventrouter/internal/atom_lock.h
@@ -1,0 +1,43 @@
+#ifndef EVENTROUTER_ATOM_LOCK_H
+#define EVENTROUTER_ATOM_LOCK_H
+
+#include <stdbool.h>
+
+#include "atomic.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /// A lock-like abstraction that doesn't support blocking. Clients may try
+    /// to take the lock or release it once taken. This type of lock *does not*
+    /// involve the operating system so trying to take it is cheap and it can be
+    /// used safely in interrupt contexts. Since this lock does not block it can
+    /// be used with locks that block without introducing a deadlock; these
+    /// locks don't prevent deadlocks, but they can't add them either.
+    typedef atomic_flag ErAtomLock_t;
+
+    /// Returns true if the lock was successfully taken and false otherwise.
+    /// Asserts if `a_lock` is `NULL`.
+    __attribute__((unused)) static inline bool ErAtomLockTryTake(
+        volatile ErAtomLock_t *a_lock)
+    {
+        return atomic_flag_test_and_set(a_lock) == 0;
+    }
+
+    /// Releases the lock if taken and does nothing otherwise. Asserts if
+    /// `a_lock` is `NULL`.
+    __attribute__((unused)) static inline void ErAtomLockGive(
+        ErAtomLock_t *a_lock)
+    {
+        atomic_flag_clear(a_lock);
+    }
+
+#define ER_ATOM_LOCK_INIT ATOMIC_FLAG_INIT
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EVENTROUTER_ATOM_LOCK_H */

--- a/extra/example/module_sensor_data_publisher.c
+++ b/extra/example/module_sensor_data_publisher.c
@@ -17,7 +17,9 @@ static SensorDataEvent_t s_event = {
 
 void SensorDataPublisher_GenerateData()
 {
-    if (!ErEventIsInFlight(&s_event.m_event))
+#ifdef ER_CONFIG_OS
+    if (ErTryClaim(TO_ER_EVENT(s_event)))
+#endif
     {
         s_event.m_temperature_c = rand() % 100;
         s_event.m_lux           = rand() % 50;


### PR DESCRIPTION
This PR adds a mechanism for safely sending events from tasks outside of the "owning task". The phrase "owning task" is explained in a documentation update in `eventrouter.h`.

If the comments in `eventrouter.h` don't explain why this change is necessary clearly, I should probably update it.