### PR TITLE
Fix atomics in C++

### DIFF
--- a/eventrouter/internal/atomic.h
+++ b/eventrouter/internal/atomic.h
@@ -5,12 +5,8 @@
 /// in both C and C++ files.
 #ifdef __cplusplus
 #include <atomic>
-#ifndef atomic_int
-#define atomic_int std::atomic<int>
-#endif
-#ifndef atomic_flag
-#define atomic_flag std::atomic_flag
-#endif
+using std::atomic_int;
+using std::atomic_flag;
 // Add more aliases here if necessary.
 #else
 #include <stdatomic.h>


### PR DESCRIPTION
`atomic_int` and `atomic_flag` in C++ are not macros, but typedefs, thus `#ifndef` check fails and C++ users get this macro defined for `atomic_int`:

```c++
`#`define atomic_int std::atomic<int>
```

If then somebody tries to use `atomic_int` with a fully qualified name, i.e. as `std::atomic_int`, they get a cryptic error saying `std in namespace std does not name a type`.

Simply importing `atomic_int` and `atomic_flag` into a global namespace fixes the issue, as this means that both uses are legal:

* `atomic_int`, which is what used in Event Router
* `std::atomic_int`, which might be used in other C++ code.