### PR TITLE
Update DefaultSendEvent logic not to wait for queue to be cleaned up if it is full

### DIFF
--- a/eventrouter/internal/eventrouter_os.c
+++ b/eventrouter/internal/eventrouter_os.c
@@ -90,9 +90,7 @@ static void DefaultSendEvent(ErQueueHandle_t a_queue, void *a_event)
     }
     else
     {
-        ER_ASSERT_E(
-            pdTRUE == xQueueSendToBack(a_queue, &a_event, portMAX_DELAY),
-            a_event);
+        ER_ASSERT_E(pdTRUE == xQueueSendToBack(a_queue, &a_event, 0), a_event);
     }
 }
 


### PR DESCRIPTION
Before this PR, it seems if we send a event to a queue where it is full, it waits forever until queue will be cleaned-up.
Sometimes it makes watchdog to trap and crash the app silently.

Most of case, we should increase the queue size for these case.
With this change, if queue is full, it asserts with printing logs.
I hope this will help future debugging