### PR TITLE
Run GitHub actions on Node 20 rather than Node 16

### DIFF
--- a/.github/workflows/pull-request-acceptance.yml
+++ b/.github/workflows/pull-request-acceptance.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Ninja
         uses: seanmiddleditch/gha-setup-ninja@master
       - name: Build And Test


### PR DESCRIPTION
Node 16 has reached EOL and is deprecated.
GitHub is transitioning to Node 20:

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/