### PR TITLE
Remove extra semicolon

### DIFF
--- a/eventrouter/internal/defs.h
+++ b/eventrouter/internal/defs.h
@@ -1,7 +1,7 @@
 #ifndef EVENTROUTER_DEFS_H
 #define EVENTROUTER_DEFS_H
 
-#define ER_UNUSED(statement) (void)(statement);
+#define ER_UNUSED(statement) (void)(statement)
 
 /// Returns the address of the structure containing the member.
 


### PR DESCRIPTION
Hi!
There is an extra semicolon in the ER_UNUSED macro that is unnecessary and I would like to remove it.
